### PR TITLE
Fix "View [components.file-upload] not found" on Filament v5.7+

### DIFF
--- a/resources/views/forms/components/advanced-file-upload.blade.php
+++ b/resources/views/forms/components/advanced-file-upload.blade.php
@@ -32,6 +32,14 @@
         x-load-src="{{ FilamentAsset::getAlpineComponentSrc('filepond-pdf', 'asmit/filament-upload') }}"
         x-load-css="[@js(FilamentAsset::getStyleHref(id: 'filepond-pdf', package: 'asmit/filament-upload'))]"
     >
-        @include('filament-forms::components.file-upload')
+        {{-- Filament v5.7 removed the `filament-forms::components.file-upload` Blade
+            view and switched FileUpload to an embedded (HasEmbeddedView) renderer.
+            Fall back to it when the Blade view is gone, while staying compatible
+            with Filament v3/v4 which still ship the view. --}}
+        @if (view()->exists('filament-forms::components.file-upload'))
+            @include('filament-forms::components.file-upload')
+        @else
+            {!! $toEmbeddedHtml() !!}
+        @endif
     </div>
 </div>


### PR DESCRIPTION
## Problem

On Filament **v5.7.0+**, every form containing an `AdvancedFileUpload` field throws at render time:

```
InvalidArgumentException: View [components.file-upload] not found.
(View: .../asmit/filament-upload/resources/views/forms/components/advanced-file-upload.blade.php)
```

## Root cause

The component view ends with:

```blade
@include('filament-forms::components.file-upload')
```

That Blade view **existed in Filament ≤ v5.6** but was **removed in v5.7.0**, where `Filament\Forms\Components\FileUpload` was converted to an embedded renderer (`implements HasEmbeddedView` → `toEmbeddedHtml()`) as part of Filament's ongoing migration of components off Blade views. With the view gone, the `@include` fails and takes down any page rendering the field.

This is not triggered by a change in this package — it surfaces on a plain `composer update` of Filament from 5.6.x to 5.7.x, so `composer.json` still advertising `^5.0` is now misleading for affected users.

Verified against the framework source:
- `filament/forms` **v5.6.8** → `resources/views/components/file-upload.blade.php` **present**
- `filament/forms` **v5.7.1** → same path **404 (removed)**

## Fix

Render the embedded HTML when the legacy Blade view is no longer available, while keeping the `@include` path for Filament v3/v4 which still ship it:

```blade
@if (view()->exists('filament-forms::components.file-upload'))
    @include('filament-forms::components.file-upload')
@else
    {!! $toEmbeddedHtml() !!}
@endif
```

`$toEmbeddedHtml()` is exposed to the view through the same public-method-closure mechanism already used in this template (`$getStatePath()`, `$isPreviewable()`, …), and produces exactly the FilePond markup the removed Blade view used to render — so the PDF-preview wrapper keeps working unchanged. The `else` branch only executes on versions where `FileUpload` is a `HasEmbeddedView`, i.e. precisely where `toEmbeddedHtml()` exists.

## Compatibility

- **Filament v3 / v4** — Blade view still present → unchanged (`@include` path).
- **Filament v5.7+** — Blade view removed → embedded renderer path.

No public API changes; single-view change; no config or asset changes.

## Testing

Rendered a form with `AdvancedFileUpload::make('documents')->multiple()->acceptedFileTypes(['application/pdf','image/*'])->pdfToolbar(true)->pdfNavPanes(true)` on Filament v5.7.1 — 500 before, renders (with PDF preview) after. Confirmed still rendering on Filament v5.6.8 via the `@include` branch.
